### PR TITLE
feat: 로그인하지 않았을 때만 로그인 버튼 표시

### DIFF
--- a/frontend/src/components/common/Header.jsx
+++ b/frontend/src/components/common/Header.jsx
@@ -1,10 +1,25 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import * as S from "./Header.style";
-import { Link, Links } from "react-router-dom";
+import { Link } from "react-router-dom";
 import logopng from "./logo.png";
 import buttonmypagepng from "./button_mypage.png";
 
 export default function Header() {
+
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  useEffect(() => {
+    const storedLogin = localStorage.getItem("loggedIn");
+    if (storedLogin === "true") {
+      setIsLoggedIn(true);
+    }
+  }, []);
+
+  const handleLogin = () => {
+    localStorage.setItem("loggedIn", "true");
+    setIsLoggedIn(true);
+  };
+
   return (
     <S.Header>
       <Link to="/main">
@@ -13,9 +28,11 @@ export default function Header() {
         </S.Logo>
       </Link>
       <S.Nav>
-        <Link to="/">
-          <S.BuyButton>로그인</S.BuyButton>
-        </Link>
+        {!isLoggedIn && (
+          <Link to="/">
+            <S.BuyButton onClick={handleLogin}>로그인</S.BuyButton>
+          </Link>
+        )}
         <Link to="/main">
           <S.BuyButton>중고거래</S.BuyButton>
         </Link>


### PR DESCRIPTION
백엔드 API 연결 전이기 때문에, 일단 프론트엔드 측에서 로그인을 했을 경우 헤더의 로그인 버튼이 보이지 않도록 수정하였습니다!

- 로그인 전
![image](https://github.com/user-attachments/assets/4ed00793-1d4a-4518-814c-d930ee1be17f)

- 로그인 후
![image](https://github.com/user-attachments/assets/796c1bf2-c4c1-48bd-a3af-5a39b3b80260)